### PR TITLE
Fix charge items (Wizard Oil, Mana Oil, etc.) being treated as stacks

### DIFF
--- a/core/stack.lua
+++ b/core/stack.lua
@@ -51,9 +51,9 @@ function find_empty_slot()
 	end
 end
 
-function find_charge_item_slot()
+function find_charge_item_slot(target_charges)
 	for slot in info.inventory() do
-		if matching_item(slot) and charges(slot) == state.target_size then
+		if matching_item(slot) and charges(slot) == target_charges then
 			return slot
 		end
 	end
@@ -82,7 +82,7 @@ function process()
 		end
 	end
 	if charges(state.target_slot) then
-		state.target_slot = find_charge_item_slot()
+		state.target_slot = find_charge_item_slot(state.target_size)
 		return stop()
 	end
 	if stack_size(state.target_slot) > state.target_size then

--- a/util/filter.lua
+++ b/util/filter.lua
@@ -191,9 +191,9 @@ M.filters = {
 					if vendor_price then 
 						local charges = 1
 						if info.max_item_charges(auction_record.item_id) ~= nil then 
-							info.charges=info.max_item_charges(auction_record.item_id) 
+							charges = info.max_item_charges(auction_record.item_id) 
 						end
-						vendor_price= vendor_price/ charges 
+						vendor_price = vendor_price / charges 
 					 end
 				end
                 return vendor_price and vendor_price * auction_record.aux_quantity - auction_record.bid_price >= amount
@@ -211,9 +211,9 @@ M.filters = {
 					if vendor_price then 
 						local charges = 1
 						if info.max_item_charges(auction_record.item_id) ~= nil then 
-							info.charges=info.max_item_charges(auction_record.item_id) 
+							charges = info.max_item_charges(auction_record.item_id) 
 						end
-						vendor_price= vendor_price/ charges 
+						vendor_price = vendor_price / charges 
 					 end
 				end
                 return auction_record.buyout_price > 0 and vendor_price and vendor_price * auction_record.aux_quantity - auction_record.buyout_price >= amount

--- a/util/info.lua
+++ b/util/info.lua
@@ -48,8 +48,9 @@ function M.container_item(bag, slot)
 
         local texture, count, locked, quality, readable, lootable = GetContainerItemInfo(bag, slot) -- quality not working?
         local tooltip, tooltip_money = tooltip('bag', bag, slot)
-        local max_charges = max_item_charges(item_id)
-        local charges = max_charges and item_charges(tooltip)
+        -- Auto-detect charges from tooltip for any item, fall back to hardcoded max_charges
+        local charges = item_charges(tooltip)
+        local max_charges = max_item_charges(item_id) or charges  -- Use detected charges as max if not in hardcoded list
         local aux_quantity = charges or count
         return T.map(
             'item_id', item_id,
@@ -306,7 +307,7 @@ do
 				return max(1, charges) -- TODO kronos bug? should never be 0
 			end
 	    end
-	    return 1
+	    return nil  -- Return nil if no charges found (not a charged item)
 	end
 end
 


### PR DESCRIPTION

Charge-based items (Wizard Oil, Mana Oil, Discombobulator Ray, Recombobulator, Deflector) were fundamentally broken in the Post tab. The addon treated charge counts as stack sizes, which meant:

- Stack Count was stuck at 1 — you couldn't batch-post multiple charge items
- Stack Size slider was shown but meaningless (you can't split/combine charges)
- Pricing, undercut, vendor price, and profit/loss calculations were all wrong
- The vendor-profit and bid-vendor-profit search filters overvalued charge items by a factor of their charge count